### PR TITLE
Update scraper.rb with Pry requirement

### DIFF
--- a/lib/scraper.rb
+++ b/lib/scraper.rb
@@ -1,5 +1,6 @@
 require 'nokogiri'
 require 'open-uri'
+require 'pry'
 
 require_relative './course.rb'
 


### PR DESCRIPTION
Course lesson states `Notice that we are already requiring Nokogiri, open-uri and Pry at the top of the file`. However, Pry is not listed by default.